### PR TITLE
Update ValueAnnotationMetadataBuilder.java

### DIFF
--- a/spring-value-annotation-processor/src/main/java/com/github/egoettelmann/spring/configuration/extensions/annotationprocessor/value/core/ValueAnnotationMetadataBuilder.java
+++ b/spring-value-annotation-processor/src/main/java/com/github/egoettelmann/spring/configuration/extensions/annotationprocessor/value/core/ValueAnnotationMetadataBuilder.java
@@ -6,7 +6,7 @@ import java.util.regex.Pattern;
 
 public class ValueAnnotationMetadataBuilder {
 
-    private static final Pattern PATTERN = Pattern.compile("\\$\\{([^}]*)}");
+    private static final Pattern PATTERN = Pattern.compile("\\$\\{(.*)}");
 
     private static final String DEFAULT_VALUE_SEPARATOR = ":";
 


### PR DESCRIPTION
Fixed regular expressions to support scenarios like `${a:${b}}`.