### PR TITLE
Change fixed version number to placeholder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             OLD_PROJECT_VERSION=$(mvn help:evaluate -N -Dexpression=project.version|grep -v '\[')
             mvn versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             PROJECT_VERSION=$(mvn help:evaluate -N -Dexpression=project.version|grep -v '\[')
-            find ./ -iname "README.md" -exec sed -i "s,<version>$OLD_PROJECT_VERSION</version>,<version>$PROJECT_VERSION</version>,g" "{}" ";"
+            find ./ -iname "*README.md" -exec sed -i "s,<version>$OLD_PROJECT_VERSION</version>,<version>$PROJECT_VERSION</version>,g" "{}" ";"
             git config user.name "<< pipeline.parameters.git-user >>"
             git config user.email "<< pipeline.parameters.git-email >>"
             git add .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Spring Configuration Extensions
 ==========
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.github.egoettelmann/spring-configuration-extensions?style=flat-square&label=Maven%20Central)](https://search.maven.org/artifact/com.github.egoettelmann/spring-configuration-extensions)
-[![CircleCI build (develop)](https://img.shields.io/circleci/build/github/egoettelmann/spring-configuration-extensions/develop?label=Develop&style=flat-square)](https://app.circleci.com/pipelines/github/egoettelmann/spring-configuration-extensions?branch=develop)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.egoettelmann/spring-configuration-extensions?color=blue&label=Maven%20Central&logo=Apache%20Maven&logoColor=orange&style=flat-square)](https://search.maven.org/artifact/com.github.egoettelmann/spring-configuration-extensions)
+[![CircleCI build (develop)](https://img.shields.io/circleci/build/github/egoettelmann/spring-configuration-extensions/develop?label=develop&logo=circleci&style=flat-square)](https://app.circleci.com/pipelines/github/egoettelmann/spring-configuration-extensions?branch=develop)
 
 This project is intended to provide some tools around Spring configurations.
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-configuration-extensions</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.2</version>
+    <version>0.1.3-SNAPSHOT</version>
     <name>Spring Configuration Extensions</name>
     <description>Extensions for Spring Configurations management</description>
 

--- a/spring-configuration-aggregator-maven-plugin/README.md
+++ b/spring-configuration-aggregator-maven-plugin/README.md
@@ -1,8 +1,8 @@
 Spring Configuration Extensions: Aggregator Maven Plugin
 ==========
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.github.egoettelmann/spring-configuration-aggregator-maven-plugin?style=flat-square&label=Maven%20Central)](https://search.maven.org/artifact/com.github.egoettelmann/spring-configuration-aggregator-maven-plugin)
-[![CircleCI build (develop)](https://img.shields.io/circleci/build/github/egoettelmann/spring-configuration-extensions/develop?label=Develop&style=flat-square)](https://app.circleci.com/pipelines/github/egoettelmann/spring-configuration-extensions?branch=develop)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.egoettelmann/spring-configuration-aggregator-maven-plugin?style=flat-square&color=blue&label=Maven%20Central&logo=Apache%20Maven&logoColor=orange)](https://search.maven.org/artifact/com.github.egoettelmann/spring-configuration-aggregator-maven-plugin)
+[![CircleCI build (develop)](https://img.shields.io/circleci/build/github/egoettelmann/spring-configuration-extensions/develop?label=develop&logo=circleci&style=flat-square)](https://app.circleci.com/pipelines/github/egoettelmann/spring-configuration-extensions?branch=develop)
 
 Maven plugin that aggregates all Spring configuration metadata
 files of the project dependencies into a single one.
@@ -43,7 +43,7 @@ You can simply add the project to the build plugin section.
 <plugin>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-configuration-aggregator-maven-plugin</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.2</version>
     <executions>
         <execution>
             <goals>
@@ -137,7 +137,7 @@ Simple aggregation, with following additional options:
 <plugin>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-configuration-aggregator-maven-plugin</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.2</version>
     <configuration>
         <!-- Ignores errors -->
         <failOnError>false</failOnError>
@@ -172,7 +172,7 @@ Simple aggregation, by only including properties from:
 <plugin>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-configuration-aggregator-maven-plugin</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.2</version>
     <configuration>
         <includeDependencies>
             <!-- Includes only metadata defined in dependencies with same 'groupId' as current project -->
@@ -199,7 +199,7 @@ Aggregation and reporting of all configuration properties.
 <plugin>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-configuration-aggregator-maven-plugin</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.2</version>
     <configuration>
         <outputReports>
             <!-- Generating default JSON report -->
@@ -238,7 +238,7 @@ Simple aggregation, that declares custom configuration files to load default val
 <plugin>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-configuration-aggregator-maven-plugin</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.2</version>
     <configuration>
         <!-- Loading default values from custom configuration file -->        
         <propertiesFiles>

--- a/spring-configuration-aggregator-maven-plugin/README.md
+++ b/spring-configuration-aggregator-maven-plugin/README.md
@@ -43,7 +43,7 @@ You can simply add the project to the build plugin section.
 <plugin>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-configuration-aggregator-maven-plugin</artifactId>
-    <version>0.1.2</version>
+    <version>@LATEST_VERSION@</version>
     <executions>
         <execution>
             <goals>
@@ -137,7 +137,7 @@ Simple aggregation, with following additional options:
 <plugin>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-configuration-aggregator-maven-plugin</artifactId>
-    <version>0.1.2</version>
+    <version>@LATEST_VERSION@</version>
     <configuration>
         <!-- Ignores errors -->
         <failOnError>false</failOnError>
@@ -172,7 +172,7 @@ Simple aggregation, by only including properties from:
 <plugin>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-configuration-aggregator-maven-plugin</artifactId>
-    <version>0.1.2</version>
+    <version>@LATEST_VERSION@</version>
     <configuration>
         <includeDependencies>
             <!-- Includes only metadata defined in dependencies with same 'groupId' as current project -->
@@ -199,7 +199,7 @@ Aggregation and reporting of all configuration properties.
 <plugin>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-configuration-aggregator-maven-plugin</artifactId>
-    <version>0.1.2</version>
+    <version>@LATEST_VERSION@</version>
     <configuration>
         <outputReports>
             <!-- Generating default JSON report -->
@@ -238,7 +238,7 @@ Simple aggregation, that declares custom configuration files to load default val
 <plugin>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-configuration-aggregator-maven-plugin</artifactId>
-    <version>0.1.2</version>
+    <version>@LATEST_VERSION@</version>
     <configuration>
         <!-- Loading default values from custom configuration file -->        
         <propertiesFiles>

--- a/spring-configuration-aggregator-maven-plugin/pom.xml
+++ b/spring-configuration-aggregator-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>spring-configuration-extensions</artifactId>
         <groupId>com.github.egoettelmann</groupId>
-        <version>0.1.2</version>
+        <version>0.1.3-SNAPSHOT</version>
     </parent>
     <artifactId>spring-configuration-aggregator-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/spring-configuration-extensions-samples/pom.xml
+++ b/spring-configuration-extensions-samples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>spring-configuration-extensions</artifactId>
         <groupId>com.github.egoettelmann</groupId>
-        <version>0.1.2</version>
+        <version>0.1.3-SNAPSHOT</version>
     </parent>
     <artifactId>spring-configuration-extensions-samples</artifactId>
     <name>Spring Configuration Extensions: Samples</name>

--- a/spring-value-annotation-processor/README.md
+++ b/spring-value-annotation-processor/README.md
@@ -1,8 +1,8 @@
 Spring Configuration Extensions: Value Annotation Processor
 ==========
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.github.egoettelmann/spring-value-annotation-processor?style=flat-square&label=Maven%20Central)](https://search.maven.org/artifact/com.github.egoettelmann/spring-value-annotation-processor)
-[![CircleCI build (develop)](https://img.shields.io/circleci/build/github/egoettelmann/spring-configuration-extensions/develop?label=Develop&style=flat-square)](https://app.circleci.com/pipelines/github/egoettelmann/spring-configuration-extensions?branch=develop)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.egoettelmann/spring-value-annotation-processor?style=flat-square&color=blue&label=Maven%20Central&logo=Apache%20Maven&logoColor=orange)](https://search.maven.org/artifact/com.github.egoettelmann/spring-value-annotation-processor)
+[![CircleCI build (develop)](https://img.shields.io/circleci/build/github/egoettelmann/spring-configuration-extensions/develop?label=develop&logo=circleci&style=flat-square)](https://app.circleci.com/pipelines/github/egoettelmann/spring-configuration-extensions?branch=develop)
 
 An annotation processor to extract all configuration properties injected through Spring `@Value` annotations.
 
@@ -16,7 +16,7 @@ If using Maven, you can simply add the project as a `provided` dependency.
 <dependency>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-value-annotation-processor</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.2</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -34,7 +34,7 @@ The plugin's configuration should look to something like the following:
             <annotationProcessorPath>
                 <groupId>com.github.egoettelmann</groupId>
                 <artifactId>spring-value-annotation-processor</artifactId>
-                <version>0.1.0</version>
+                <version>0.1.2</version>
             </annotationProcessorPath>
         </annotationProcessorPaths>
     </configuration>
@@ -61,7 +61,7 @@ Configuration would be as follows:
             <annotationProcessorPath>
                 <groupId>com.github.egoettelmann</groupId>
                 <artifactId>spring-value-annotation-processor</artifactId>
-                <version>0.1.0</version>
+                <version>0.1.2</version>
             </annotationProcessorPath>
         </annotationProcessorPaths>
         <compilerArgs>

--- a/spring-value-annotation-processor/README.md
+++ b/spring-value-annotation-processor/README.md
@@ -16,7 +16,7 @@ If using Maven, you can simply add the project as a `provided` dependency.
 <dependency>
     <groupId>com.github.egoettelmann</groupId>
     <artifactId>spring-value-annotation-processor</artifactId>
-    <version>0.1.2</version>
+    <version>@LATEST_VERSION@</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -34,7 +34,7 @@ The plugin's configuration should look to something like the following:
             <annotationProcessorPath>
                 <groupId>com.github.egoettelmann</groupId>
                 <artifactId>spring-value-annotation-processor</artifactId>
-                <version>0.1.2</version>
+                <version>@LATEST_VERSION@</version>
             </annotationProcessorPath>
         </annotationProcessorPaths>
     </configuration>
@@ -61,7 +61,7 @@ Configuration would be as follows:
             <annotationProcessorPath>
                 <groupId>com.github.egoettelmann</groupId>
                 <artifactId>spring-value-annotation-processor</artifactId>
-                <version>0.1.2</version>
+                <version>@LATEST_VERSION@</version>
             </annotationProcessorPath>
         </annotationProcessorPaths>
         <compilerArgs>

--- a/spring-value-annotation-processor/pom.xml
+++ b/spring-value-annotation-processor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>spring-configuration-extensions</artifactId>
         <groupId>com.github.egoettelmann</groupId>
-        <version>0.1.2</version>
+        <version>0.1.3-SNAPSHOT</version>
     </parent>
     <artifactId>spring-value-annotation-processor</artifactId>
     <name>Spring Configuration Extensions: Value Annotation Processor</name>


### PR DESCRIPTION
Change the fixed version number to a placeholder;   
**1. No need to maintain version number every time (there is a possibility of omission)**   
**2. The user will change the version number after copying the example (the placeholder is an invalid version number)**  

The reasons for this PR are: After found this library, I copied the sample from `README.md` to use (the default `master `branch `README.md`); because the copy can be used in the past, so I forgot to update the version number to the latest, resulting in some problems/or new features that cannot be used;