### PR TITLE
Fix the order of the contents of the json file

### DIFF
--- a/spring-configuration-aggregator-maven-plugin/src/main/java/com/github/egoettelmann/spring/configuration/extensions/aggregator/maven/components/aggregation/AggregationBuilder.java
+++ b/spring-configuration-aggregator-maven-plugin/src/main/java/com/github/egoettelmann/spring/configuration/extensions/aggregator/maven/components/aggregation/AggregationBuilder.java
@@ -70,6 +70,9 @@ public class AggregationBuilder {
                 // Property exists already: merging
                 final AggregatedPropertyMetadata aggregate = aggregationMap.get(property.getName());
                 this.merge(aggregate, property, groupId, artifactId);
+                // sorted SourceType list
+                aggregate.getSourceTypes().stream()
+                    .sorted(Comparator.comparing(source -> String.format("%s.%s.%s", source.getGroupId(), source.getArtifactId(), source.getSourceType()))).collect(Collectors.toList());
             }
         }
 


### PR DESCRIPTION
Replace ArrayList with LinkedList and HashMap with LinkedHashMap to fix the order of the contents of the json file.  

Our company adds the **configurations.json** file output by `aggregate` to the version management system to monitor the configuration information changes of the project; Then I found that when the project configuration did not actually change, the content of each `aggregate` was inconsistent because the order of the content was not fixed. For example, the array content order of **sourceTypes**; This can introduce unintended content versioning noise.